### PR TITLE
Downgrade piraeus csi

### DIFF
--- a/kubernetes/apps/piraeus/app/kustomization.yaml
+++ b/kubernetes/apps/piraeus/app/kustomization.yaml
@@ -34,3 +34,8 @@ patches:
     target:
       kind: ConfigMap
       name: piraeus-datastore-dashboard
+
+images:
+  - name: quay.io/piraeusdatastore/piraeus-csi
+    newTag: 1.10.0 # renovate: ignore
+


### PR DESCRIPTION
fsckl fails because the volume is mounted before it runs. Revert until fixed.