### PR TITLE
Update DRDB verification algorithm

### DIFF
--- a/kubernetes/apps/piraeus/app/cluster.yaml
+++ b/kubernetes/apps/piraeus/app/cluster.yaml
@@ -2,4 +2,7 @@ apiVersion: piraeus.io/v1
 kind: LinstorCluster
 metadata:
   name: linstorcluster
-spec: {}
+spec:
+  properties:
+    - name: DrbdOptions/Net/verify-alg
+      value: "crc32c"


### PR DESCRIPTION
crct10dif is removed from the linux kernel